### PR TITLE
Improve proverc documentation

### DIFF
--- a/bin/pg_prove
+++ b/bin/pg_prove
@@ -444,6 +444,11 @@ command line options:
 Under Windows and VMS the option file is named F<_proverc> rather than
 F<.proverc> and is sought only in the current directory.
 
+Due to how options are loaded you cannot use F<.proverc> for pg_prove options,
+only App::Prove options.  However pg_prove does support all of the usual libpq
+L<Environment
+Variables|http://www.postgresql.org/docs/current/static/libpq-envars.html>.
+
 =item C<--norc>
 
 Do not process F<./.proverc> or F<~/.proverc>.


### PR DESCRIPTION
Note that proverc is only for App::Prove options.  However pg_prove
can make use of libpq environment variables.
