### PR TITLE
Use named types in pg_tapgen generated function body tests

### DIFF
--- a/bin/pg_tapgen
+++ b/bin/pg_tapgen
@@ -251,7 +251,7 @@ sub sequences_are {
 sub functions_are {
     my $schema = shift;
     my $sth = $dbh->prepare(q{
-        SELECT p.proname, md5(p.prosrc) as md5, proargtypes::text
+        SELECT p.proname, md5(p.prosrc) as md5, oidvectortypes(proargtypes) as proargs
           FROM pg_catalog.pg_proc p
           JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
          WHERE n.nspname = ?
@@ -266,12 +266,12 @@ sub functions_are {
     $total_tests++;
     for my $row (@$allfuncs) {
         my ($proname, $md5, $proargs)=@$row;
-        print qq{SELECT is(md5(p.prosrc), '$md5', 'Function $proname body should match checksum')
-  FROM pg_catalog.pg_proc p
-  JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
- WHERE n.nspname = '$schema'
-   AND proname = '$proname'
-   AND proargtypes::text = '$proargs';\n\n};
+        print qq{SELECT is(md5(p.prosrc), '$md5', 'Function $schema.$proname($proargs) body should match checksum')
+FROM pg_catalog.pg_namespace n
+  LEFT JOIN pg_catalog.pg_proc p ON p.pronamespace = n.oid
+                                AND proname = '$proname'
+                                AND oidvectortypes(proargtypes) = '$proargs'
+WHERE n.nspname = '$schema';\n\n};
         $total_tests++;
     }
 #

--- a/bin/pg_tapgen
+++ b/bin/pg_tapgen
@@ -255,13 +255,16 @@ sub functions_are {
           FROM pg_catalog.pg_proc p
           JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
          WHERE n.nspname = ?
-         ORDER BY p.proname
+         ORDER BY p.proname, proargs
     });
     my $allfuncs = $dbh->selectall_arrayref($sth, undef, $schema);
     return unless $allfuncs && @$allfuncs;
-    my %funcs=map{$_->[0] => undef} @$allfuncs;
+    my @funcs = do {
+        my %seen;
+        grep { !$seen{$_}++ } map { $_->[0] } @$allfuncs;
+    };
     print "SELECT functions_are('$schema', ARRAY[\n    '",
-        join("',\n    '", sort keys %funcs),
+        join("',\n    '", @funcs),
         "'\n]);\n\n";
     $total_tests++;
     for my $row (@$allfuncs) {

--- a/bin/pg_tapgen
+++ b/bin/pg_tapgen
@@ -259,9 +259,9 @@ sub functions_are {
     });
     my $allfuncs = $dbh->selectall_arrayref($sth, undef, $schema);
     return unless $allfuncs && @$allfuncs;
-    my @funcs=map{$_->[0]} @$allfuncs;
+    my %funcs=map{$_->[0] => undef} @$allfuncs;
     print "SELECT functions_are('$schema', ARRAY[\n    '",
-        join("',\n    '", @funcs),
+        join("',\n    '", sort keys %funcs),
         "'\n]);\n\n";
     $total_tests++;
     for my $row (@$allfuncs) {


### PR DESCRIPTION
Currently, function body MD5 tests look up the specialization of the function being tested using the raw OIDs of it's arguments. These OIDs are only consistent between databases for built-in types. This means functions using extension types (I.E. hstore) will have differing argument OIDs on different machines, causing tests to fail. Worse, due to the structure of the query the test is not run, meaning only a plan failure results.

This PR corrects both issues in what I believe is a reasonable way for the majority of cases. Unlike the more sophisticated function introspection tools available today, `oidvectortypes` is available on all supported PG versions. And while plan failures will still result if the schema is not present, other direct failures will invariably result from such a situation. As such, I felt keeping the query simple was worth a moderate compromise  in function.

The duplicate name elimination is just a bonus, the only function change is shorter output. Included as I feel it makes it clearer that this test does not count overloads of the same function name.